### PR TITLE
ensure static memory is not reachable on program exit

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -28,7 +28,7 @@ FILES  = ft_isalpha.c ft_isdigit.c ft_isalnum.c ft_isascii.c ft_isprint.c ft_str
                         ft_printf.c ft_print_hexa_printf.c ft_putchar_printf.c ft_putnbr_printf.c \
                         ft_putstr_printf.c \
                         \
-                        get_next_line.c get_next_line_utils.c \
+                        get_next_line.c get_next_line_utils.c get_next_line_utils2.c \
 
 SRC = $(addprefix $(SRC_DIR)/, $(FILES))
 INC = includes/

--- a/libft/includes/get_next_line.h
+++ b/libft/includes/get_next_line.h
@@ -31,5 +31,6 @@ void	*ft_calloc_gnl(size_t nmemb, size_t size);
 int		ft_strlen_gnl(char *str);
 char	*ft_strcpy_gnl(char *dest, char *src);
 int		ft_strchr_gnl(const char *s, int c);
+void	free_gnl_buffer(int fd);
 
 #endif

--- a/libft/sources/ft_putnbr_printf.c
+++ b/libft/sources/ft_putnbr_printf.c
@@ -41,13 +41,7 @@ size_t	ft_put_u_nbr_printf(unsigned int nb)
 	size_t	arg_len;
 
 	arg_len = 0;
-	if (nb < 0)
-	{
-		ft_putchar_printf('-');
-		nb *= -1;
-		arg_len++;
-	}
-	if (nb >= 0 && nb <= 9)
+	if (nb <= 9)
 	{
 		ft_putchar_printf('0' + nb);
 		arg_len++;

--- a/libft/sources/get_next_line.c
+++ b/libft/sources/get_next_line.c
@@ -13,107 +13,28 @@
 #include "get_next_line.h"
 #include "libft.h"
 
-char	*ft_cut_line(char *reserve)
+static char	**gnl_get_internal_buffer(void)
 {
-	int	i;
-
-	i = 0;
-	while (reserve != NULL && reserve[i] && reserve[i] != '\n')
-		i++;
-	if (reserve != NULL && reserve[i] && reserve[i] == '\n')
-		i++;
-	ft_strcpy_gnl(reserve, &reserve[i]);
-	return (reserve);
+	static char *str[1024];
+	return (str);
 }
 
-char	*ft_copy_from_buffer(char *reserve, char *buffer)
+void	free_gnl_buffer(int fd)
 {
-	int		i;
-	int		j;
-	char	*array;
-
-	i = 0;
-	j = 0;
-	array = (char *)ft_calloc((ft_strlen(reserve) + ft_strlen(buffer) + 1), 1);
-	if (!array || !reserve || !buffer)
-		return (NULL);
-	while (reserve[i] && reserve != NULL)
+	char **str = gnl_get_internal_buffer();
+	if (str[fd])
 	{
-		array[i] = reserve[i];
-		i++;
+		free(str[fd]);
+		str[fd] = NULL;
 	}
-	while (buffer[j] && buffer != NULL)
-	{
-		array[i] = buffer[j];
-		i++;
-		j++;
-	}
-	array[i] = '\0';
-	return (free(reserve), array);
-}
-
-char	*ft_get_line(char *full_reserve)
-{
-	char	*line;
-	int		i;
-
-	i = 0;
-	while (full_reserve[i] && full_reserve[i] != '\n')
-		i++;
-	if (full_reserve[i] == '\n')
-		i++;
-	line = (char *)ft_calloc(sizeof(char), (i + 1));
-	if (!line)
-		return (free(full_reserve), NULL);
-	i = 0;
-	while (full_reserve != NULL && full_reserve[i] && full_reserve[i] != '\n')
-	{
-		line[i] = full_reserve[i];
-		i++;
-	}
-	if (full_reserve[i] == '\n')
-	{
-		line[i] = full_reserve[i];
-		i++;
-	}
-	line[i] = '\0';
-	return (line);
-}
-
-char	*ft_read_buffer(int fd, char *reserve)
-{
-	char	*buffer;
-	int		read_return;
-
-	read_return = 1;
-	buffer = ft_calloc(BUFFER_SIZE + 1, sizeof(char));
-	if (!buffer)
-		return (free(reserve), NULL);
-	if (!reserve)
-	{
-		reserve = (char *)ft_calloc(1, 1);
-		if (!reserve)
-			return (NULL);
-	}
-	while (read_return != 0 && !ft_strchr_gnl(reserve, '\n'))
-	{
-		read_return = read(fd, buffer, BUFFER_SIZE);
-		if (read_return < 0 || (read_return == 0 && reserve[0] == '\0'))
-			return (free(reserve), free(buffer), reserve = NULL);
-		buffer[read_return] = '\0';
-		reserve = ft_copy_from_buffer(reserve, buffer);
-		if (!reserve)
-			return (free(reserve), NULL);
-	}
-	free(buffer);
-	return (reserve);
 }
 
 char	*get_next_line(int fd)
 {
-	static char	*reserve[1024];
+	char	**reserve;
 	char		*line;
 
+	reserve = gnl_get_internal_buffer();
 	if (fd < 0 || BUFFER_SIZE <= 0)
 		return (NULL);
 	reserve[fd] = ft_read_buffer(fd, reserve[fd]);

--- a/libft/sources/get_next_line_utils2.c
+++ b/libft/sources/get_next_line_utils2.c
@@ -1,0 +1,110 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   get_next_line.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yukravch <marvin@42.fr>                    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/12 18:49:14 by yukravch          #+#    #+#             */
+/*   Updated: 2025/02/17 12:36:07 by yukravch         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "get_next_line.h"
+#include "libft.h"
+
+char	*ft_cut_line(char *reserve)
+{
+	int	i;
+
+	i = 0;
+	while (reserve != NULL && reserve[i] && reserve[i] != '\n')
+		i++;
+	if (reserve != NULL && reserve[i] && reserve[i] == '\n')
+		i++;
+	ft_strcpy_gnl(reserve, &reserve[i]);
+	return (reserve);
+}
+
+char	*ft_copy_from_buffer(char *reserve, char *buffer)
+{
+	int		i;
+	int		j;
+	char	*array;
+
+	i = 0;
+	j = 0;
+	array = (char *)ft_calloc((ft_strlen(reserve) + ft_strlen(buffer) + 1), 1);
+	if (!array || !reserve || !buffer)
+		return (NULL);
+	while (reserve[i] && reserve != NULL)
+	{
+		array[i] = reserve[i];
+		i++;
+	}
+	while (buffer[j] && buffer != NULL)
+	{
+		array[i] = buffer[j];
+		i++;
+		j++;
+	}
+	array[i] = '\0';
+	return (free(reserve), array);
+}
+
+char	*ft_get_line(char *full_reserve)
+{
+	char	*line;
+	int		i;
+
+	i = 0;
+	while (full_reserve[i] && full_reserve[i] != '\n')
+		i++;
+	if (full_reserve[i] == '\n')
+		i++;
+	line = (char *)ft_calloc(sizeof(char), (i + 1));
+	if (!line)
+		return (free(full_reserve), NULL);
+	i = 0;
+	while (full_reserve != NULL && full_reserve[i] && full_reserve[i] != '\n')
+	{
+		line[i] = full_reserve[i];
+		i++;
+	}
+	if (full_reserve[i] == '\n')
+	{
+		line[i] = full_reserve[i];
+		i++;
+	}
+	line[i] = '\0';
+	return (line);
+}
+
+char	*ft_read_buffer(int fd, char *reserve)
+{
+	char	*buffer;
+	int		read_return;
+
+	read_return = 1;
+	buffer = ft_calloc(BUFFER_SIZE + 1, sizeof(char));
+	if (!buffer)
+		return (free(reserve), NULL);
+	if (!reserve)
+	{
+		reserve = (char *)ft_calloc(1, 1);
+		if (!reserve)
+			return (NULL);
+	}
+	while (read_return != 0 && !ft_strchr_gnl(reserve, '\n'))
+	{
+		read_return = read(fd, buffer, BUFFER_SIZE);
+		if (read_return < 0 || (read_return == 0 && reserve[0] == '\0'))
+			return (free(reserve), free(buffer), reserve = NULL);
+		buffer[read_return] = '\0';
+		reserve = ft_copy_from_buffer(reserve, buffer);
+		if (!reserve)
+			return (free(reserve), NULL);
+	}
+	free(buffer);
+	return (reserve);
+}

--- a/sources/exit.c
+++ b/sources/exit.c
@@ -50,9 +50,12 @@ void	ft_close(int fd, int pipe[2])
 {
 	if (fd >= 0)
 		close(fd);
-	if (pipe >= 0)
+	if (pipe[0] >= 0)
 	{
 		close(pipe[0]);
+	}
+	if (pipe[1] >= 0)
+	{
 		close(pipe[1]);
 	}
 }

--- a/sources/pipex_bonus.c
+++ b/sources/pipex_bonus.c
@@ -106,4 +106,5 @@ int	main(int ac, char **av, char **env)
 	ft_parent_process(cmd_number, ac, av, env);
 	if (is_heredoc)
 		unlink("heredoc");
+	free_gnl_buffer(STDIN_FILENO);
 }


### PR DESCRIPTION
Hey! 👋

While running the project with Valgrind, it showed the still reachable stuf...

```
==XXXX== 5 bytes in 1 blocks are still reachable
==XXXX==    by 0x...: get_next_line BLA BLA BLA
```

It wasn’t a memory leak, just a little leftover buffer from `get_next_line`.  
That function uses a static buffer per file descriptor to keep things efficient between calls:

```c
static char *str[1024];
```

Totally normal. But since it never gets freed before the program exits, Valgrind marks it as *still reachable*. Not broken — just not cleaned up.

---

### 🔧 What I did

I added a way to manually clean it up when needed. Here’s the code (more less):

(I tried to follow the norm but I am sure it will show a lot of norm errors, check it for any potential issues)

#### Access the internal buffer:
```c
char **gnl_get_internal_buffer(void)
{
  static char *str[1024];
  return (str);
}
```

#### Free a specific FD buffer:
```c
void free_gnl_buffer(int fd)
{
  char **str = gnl_get_internal_buffer();
  if (str[fd])
  {
    free(str[fd]);
    str[fd] = NULL;
  }
}
```

#### And just call it at the end of the main (in pipex):
```c
free_gnl_buffer(STDIN_FILENO); // clean exit
```

---

### ✅ Result?

Valgrind = clean ✅  
No more "still reachable" memory ✅  
All good and ready to merge ✨

---

🖼️

![Screenshot from 2025-04-23 18-50-24](https://github.com/user-attachments/assets/aaf90f59-a33c-4101-bd81-b0ca5d8bb4ca)

